### PR TITLE
Fix linking with modern compilers

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -27,10 +27,10 @@ clean:
 
 
 $(BINDIR)/AAFInfo: AAFInfo.c thirdparty/libTC.c
-	$(CC) -o $@ $^ -L$(OBJDIR) $(CFLAGS) `pkg-config --cflags sndfile` `pkg-config --libs sndfile` -lAAF -lm
+	$(CC) -o $@ $^ -L$(OBJDIR) $(CFLAGS) `pkg-config --cflags sndfile` -lAAF `pkg-config --libs sndfile` -lm
 
 $(BINDIR)/AAFExtract: AAFExtract.c
-	$(CC) -o $@ $^ -L$(OBJDIR) $(CFLAGS) `pkg-config --cflags sndfile` `pkg-config --libs sndfile` -lAAF -lm
+	$(CC) -o $@ $^ -L$(OBJDIR) $(CFLAGS) `pkg-config --cflags sndfile` -lAAF `pkg-config --libs sndfile` -lm
 
 # $(BINDIR)/AAF2Ardour: $(OBJDIR)/Ardour.o AAF2Ardour.c
 # 	$(CC) -o $@ $^ -L$(OBJDIR) $(CFLAGS) -lsndfile -lAAF -lm


### PR DESCRIPTION
Since static libAAF depends on libsndfile and does not link against libsndfile itself it needs to be listed first.

This fixes `AAFIAudioFiles.c undefined reference to `sf_*' errors.