### PR TITLE
Add missing include, fix type ambiguity

### DIFF
--- a/include/libaaf/AAFIAudioFiles.h
+++ b/include/libaaf/AAFIAudioFiles.h
@@ -23,9 +23,7 @@
 
 #include <wchar.h>
 
-struct AAF_Iface;
-struct aafiAudioEssence;
-
+#include <libaaf/AAFIface.h>
 
 char * locate_external_essence_file( AAF_Iface *aafi, const wchar_t *original_file_path, const char *search_location );
 


### PR DESCRIPTION
`AAF_Iface` and `aafiAudioEssence` are typedef'ed structs.

The alternative would be to change the declaration to 
```
char * locate_external_essence_file( struct AAF_Iface *aafi, ...
```