### PR TITLE
Move 'aafi_enable_windows_VT100_output()' to tools/common.c

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,11 +171,13 @@ if ( BUILD_TOOLS )
 
   add_executable( AAFInfo
     ${TOOLS_SRC_PATH}/AAFInfo.c
+    ${TOOLS_SRC_PATH}/common.c
     ${TOOLS_SRC_PATH}/thirdparty/libTC.c
   )
 
   add_executable( AAFExtract
     ${TOOLS_SRC_PATH}/AAFExtract.c
+    ${TOOLS_SRC_PATH}/common.c
     ${TOOLS_SRC_PATH}/thirdparty/libTC.c
   )
 

--- a/include/libaaf/AAFIface.h
+++ b/include/libaaf/AAFIface.h
@@ -919,8 +919,6 @@ typedef struct AAF_Iface
 
 
 
-void aafi_enable_windows_VT100_output( void );
-
 void aafi_set_debug( AAF_Iface *aafi, verbosityLevel_e v, FILE *fp, void (*callback)(struct dbg *dbg, void *ctxdata, int lib, int type, const char *srcfile, const char *srcfunc, int lineno, const char *msg, void *user), void *user );
 
 AAF_Iface * aafi_alloc( AAF_Data *aafd );

--- a/src/AAFIface/AAFIface.c
+++ b/src/AAFIface/AAFIface.c
@@ -129,19 +129,6 @@ AAF_Iface * aafi_alloc( AAF_Data *aafd )
 
 
 
-void aafi_enable_windows_VT100_output( void )
-{
-#ifdef _WIN32
-	/* enables ANSI colors and unicode chars */
-	HANDLE hOut = GetStdHandle( STD_OUTPUT_HANDLE );
-	DWORD dwMode = 0;
-	GetConsoleMode( hOut, &dwMode );
-	SetConsoleMode( hOut, (dwMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING) );
-#endif
-}
-
-
-
 void aafi_set_debug( AAF_Iface *aafi, verbosityLevel_e v, FILE *fp, void (*callback)(struct dbg *dbg, void *ctxdata, int lib, int type, const char *srcfile, const char *srcfunc, int lineno, const char *msg, void *user), void *user )
 {
 	aafi->dbg->verb = v;

--- a/tools/common.c
+++ b/tools/common.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2017-2023 Adrien Gesta-Fline
+ *
+ * This file is part of libAAF.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+/**
+ * @file LibAAF/AAFIface/AAFIface.c
+ * @brief AAF processing
+ * @author Adrien Gesta-Fline
+ * @version 0.1
+ * @date 04 october 2017
+ *
+ * @ingroup AAFIface
+ * @addtogroup AAFIface
+ *
+ * The AAFIface provides the actual processing of the AAF Objects in order to show
+ * essences and clips in a simplified manner. Indeed, AAF has many different ways to
+ * store data and metadata. Thus, the AAFIface is an abstraction layer that provides
+ * a constant and unique representation method of essences and clips.
+ *
+ *
+ *
+ * @{
+ */
+
+
+#include "common.h"
+
+#ifdef _WIN32
+	#include <windows.h>
+	#ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
+		#define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
+	#endif
+#endif
+
+
+
+void aafi_enable_windows_VT100_output( void )
+{
+#ifdef _WIN32
+	/* enables ANSI colors and unicode chars */
+	HANDLE hOut = GetStdHandle( STD_OUTPUT_HANDLE );
+	DWORD dwMode = 0;
+	GetConsoleMode( hOut, &dwMode );
+	SetConsoleMode( hOut, (dwMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING) );
+#endif
+}

--- a/tools/common.h
+++ b/tools/common.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2017-2023 Adrien Gesta-Fline
+ *
+ * This file is part of libAAF.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef __commong_h__
+#define __commong_h__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void aafi_enable_windows_VT100_output( void );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // ! __utils_h__


### PR DESCRIPTION
Closes: https://github.com/agfline/LibAAF/issues/11

i haven't done any check, whether there are other "API unrelated" functions besides `aafi_enable_windows_VT100_output()`