### PR TITLE
tools: Include "common.h" for aafi_enable_windows_VT100_output()

### DIFF
--- a/tools/AAFExtract.c
+++ b/tools/AAFExtract.c
@@ -30,6 +30,7 @@
 #include <libaaf.h>
 
 #include "../src/common/utils.h" // ANSI colors, laaf_util_c99strdup()
+#include "common.h" // aafi_enable_windows_VT100_output()
 
 
 static void showHelp( void ) {

--- a/tools/AAFInfo.c
+++ b/tools/AAFInfo.c
@@ -35,6 +35,7 @@
 
 #include "./thirdparty/libTC.h"
 #include "../src/common/utils.h" // ANSI colors, laaf_util_c99strdup()
+#include "common.h" // aafi_enable_windows_VT100_output()
 
 
 


### PR DESCRIPTION
my PR #18 moved `aafi_enable_windows_VT100_output()` into a `tools/common.c` (cleaning up the API).

unfortunately, I forgot to actually include the corresponding `common.h` file in the tools, which lead to nasty warnings like:
> .../LibAAF/tools/AAFExtract.c:102:9: warning: implicit declaration of function ‘aafi_enable_windows_VT100_output’ [-Wimplicit-function-declaration]

this PR should fix this. sorry for the mess

Related: https://github.com/agfline/LibAAF/issues/11