### PR TITLE
Exclude repository configuration files from 'git archive'

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.git*      	export-ignore
+.travis.yml	export-ignore


### PR DESCRIPTION
Basically all files starting with ".git*" are meant to configure the repository. But with 'git archive' we are leaving *this* repository, and if we are ever importing the sources into another repository, we might want to configure it differently.

Closes: https://github.com/agfline/LibAAF/issues/20